### PR TITLE
[BE] Refactor: 메인 이벤트 조회 기능 리팩토링

### DIFF
--- a/BE/src/main/java/com/example/starbucks/controller/EventController.java
+++ b/BE/src/main/java/com/example/starbucks/controller/EventController.java
@@ -21,8 +21,8 @@ public class EventController {
 	}
 
 	@GetMapping("/events/main")
-	public MainEventResponse getMainEvent(@RequestParam("main") boolean param) {
-		return eventService.findMainEvent(param);
+	public MainEventResponse getMainEvent() {
+		return eventService.findMainEvent();
 	}
 
 	@GetMapping("/events")

--- a/BE/src/main/java/com/example/starbucks/dto/MainEventResponse.java
+++ b/BE/src/main/java/com/example/starbucks/dto/MainEventResponse.java
@@ -14,6 +14,9 @@ import java.time.LocalDateTime;
 public class MainEventResponse {
 
     private Long id;
+    private String title;
+    private String target;
+    private String eventProductName;
     private LocalDateTime startDateTime;
     private LocalDateTime endDateTime;
     private String description;
@@ -21,6 +24,9 @@ public class MainEventResponse {
 
     public MainEventResponse(Event event) {
         this.id = event.getId();
+        this.title = event.getTitle();
+        this.target = event.getTarget();
+        this.eventProductName = event.getEventProductName();
         this.startDateTime = event.getStartDateTime();
         this.endDateTime = event.getEndDateTime();
         this.description = event.getDescription();

--- a/BE/src/main/java/com/example/starbucks/repository/EventRepository.java
+++ b/BE/src/main/java/com/example/starbucks/repository/EventRepository.java
@@ -13,5 +13,5 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 	List<Event> findByCurrentDateTimeIsBetweenStartDateTimeAndEndDateTime(
 		@Param("currentDateTime") LocalDateTime currentDateTime);
 
-	Event findByMain(@Param("main") boolean param);
+	Event findByMainIsTrue();
 }

--- a/BE/src/main/java/com/example/starbucks/service/EventService.java
+++ b/BE/src/main/java/com/example/starbucks/service/EventService.java
@@ -25,8 +25,8 @@ public class EventService {
 			.collect(Collectors.toList());
 	}
 
-	public MainEventResponse findMainEvent(boolean param) {
-		return new MainEventResponse(eventRepository.findByMain(param));
+	public MainEventResponse findMainEvent() {
+		return new MainEventResponse(eventRepository.findByMainIsTrue());
 	}
 
 	public List<EventResponse> findAllBySort(String sortBy, String orderBy) {

--- a/BE/src/main/resources/data.sql
+++ b/BE/src/main/resources/data.sql
@@ -42,8 +42,10 @@ VALUES ('콜드브루','Cold brew', 'DRINK', 'https://image.istarbucks.co.kr/upl
 INSERT INTO event
     (title, description, start_date_time, end_date_time, main, event_product_name, target, image_url)
 VALUES
+    ('스타벅스트', '기간 내 오후 2시~6시 등록된 카드로 주문시 영수증당 별 추가 증정',
+     '2021-10-11', '2021-10-22', true, '스타벅스트 딜리버리 음료', '스타벅스트 리워드 회원', 'https://s3.ap-northeast-2.amazonaws.com/lucas-image.codesquad.kr/1627033273796event-bg.png'),
     ('22 서머 e-프리퀀시 이벤트 안내', '다가올 여행의 모양은 모두 다르지만, 즐거운 여행 속 \'나\'에게 기대감과 즐거움을 주는 스타벅스의 여름 이야기.',
-     '2022-05-01', '2023-05-01', true, '아이스 아메리카노', '모든 스타벅스 회원', null),
+     '2022-05-01', '2023-05-01', false, '아이스 아메리카노', '모든 스타벅스 회원', null),
     ('만원당 별 적립 이벤트', '회원 계정에 등록된 스타벅스 카드로 결제 시, 1만원당 별 1개를 즉시 추가로 드립니다!',
      '2022-01-01', '2023-12-31', false, '모든 상품', '스타벅스 리워드 전 회원', null),
     ('감사의 달 e-Gift 선물하기 이벤트', '스타벅스 e-Gift와 함께 고마운 마음을 전해 보세요!',

--- a/BE/src/test/java/com/example/starbucks/controller/EventControllerTest.java
+++ b/BE/src/test/java/com/example/starbucks/controller/EventControllerTest.java
@@ -8,7 +8,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.example.starbucks.config.RestDocsConfiguration;
 import com.example.starbucks.dto.EventResponse;
+import com.example.starbucks.dto.MainEventResponse;
 import com.example.starbucks.service.EventService;
+
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,11 +34,11 @@ class EventControllerTest {
     MockMvc mockMvc;
 
     @MockBean
-    EventService productService;
+    EventService eventService;
 
     @Test
     void 현재_진행중인_이벤트를_모두_조회한다() throws Exception {
-        given(productService.findOngoingEvents())
+        given(eventService.findOngoingEvents())
             .willReturn(List.of(
                 new EventResponse(1L, "http://~~~", "제목 1", "설명11111"),
                 new EventResponse(2L, "http://~~~", "제목 2", "설명22222"),
@@ -53,7 +56,7 @@ class EventControllerTest {
 
     @Test
     void 이벤트_시작_날짜를_내림차순으로_정렬한_이벤트를_모두_조회한다() throws Exception {
-        given(productService.findAllBySort("start-date-time", "desc"))
+        given(eventService.findAllBySort("start-date-time", "desc"))
             .willReturn(List.of(
                 new EventResponse(1L, "http://~~~", "제목 1", "설명11111"),
                 new EventResponse(2L, "http://~~~", "제목 2", "설명22222"),
@@ -69,4 +72,22 @@ class EventControllerTest {
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andDo(document("event-sort"));
     }
+
+//    @Test
+//    void 메인_이벤트를_조회한다() throws Exception {
+//        LocalDateTime startDate = LocalDateTime.of(2021, 10, 11, 00, 00);
+//        LocalDateTime endDate = LocalDateTime.of(2021, 10, 22, 00, 00);
+//
+//        given(eventService.findMainEvent())
+//                .willReturn(new MainEventResponse(1L, '스타벅스트', '스타벅스트 리워드 회원', '스타벅스트 딜리버리 음료',
+//                        startDate, endDate, '기간 내 오후 2시~6시 등록된 카드로 주문시 영수증당 별 추가 증정',
+//                        'https://s3.ap-northeast-2.amazonaws.com/lucas-image.codesquad.kr/1627033273796event-bg.png'));
+//
+//        ResultActions perform = mockMvc.perform(get("events/main"));
+//
+//        perform
+//                .andExpect(status().isOk())
+//                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+//                .andDo(document("main-event"));
+//    }
 }


### PR DESCRIPTION
### Description
- 메인 이벤트 조회 기능 구현

`GET /events/main`
```
{
		"id": 1,
		"title": "스타벅스트",
		"target": "스타벅스회원",
		"startDateTime": "2021년 10월 11일",
		"endDateTime": "2021년 10월 11일",
		"description": "스타벅스에서 시원한 여름을 준비하세요",
		"imageUrl": "https://s3.ap-northeast-2.amazonaws.com/1627033273796event-bg.png"
}
```

### Commit
- path parameter를 사용하지 않게 되면서 관련된 로직들 수정
- data.sql 관련 데이터 추가
- 클라이언트 단에서 추가로 필요한 필드 mainEventReponse에 추가


